### PR TITLE
Compatibility with RT Fuze mod

### DIFF
--- a/1.4/Patches/patch_RT_fuze.xml
+++ b/1.4/Patches/patch_RT_fuze.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>RT Fuse</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<success>Normal</success>
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ShipCapacitorSmall"]/comps</xpath>
+					<value>
+						<li Class="RT_Fuse.CompProperties_RTFuse">
+							<compClass>RT_Fuse.CompRTFuse</compClass>
+							<surgeMitigation>1000</surgeMitigation>
+							<breakdownOnTrip>false</breakdownOnTrip>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ShipCapacitor"]/comps</xpath>
+					<value>
+						<li Class="RT_Fuse.CompProperties_RTFuse">
+							<compClass>RT_Fuse.CompRTFuse</compClass>
+							<surgeMitigation>10000</surgeMitigation>
+							<breakdownOnTrip>false</breakdownOnTrip>
+						</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Source/1.4/ShipInteriorMod2.cs
+++ b/Source/1.4/ShipInteriorMod2.cs
@@ -131,6 +131,17 @@ namespace SaveOurShip2
 			Harmony pat = new Harmony("ShipInteriorMod2");
 			pat.Patch(regenerateMethod, postfix: new HarmonyMethod(regeneratePostfix));
 
+			
+			if (ModLister.HasActiveModWithName("RT Fuse"))
+			{
+				Log.Message("SOS2: Enabling compatibility with RT Fuze");
+			} else {
+				var doShortCircuitMethod = typeof(ShortCircuitUtility).GetMethod("DoShortCircuit");
+				var prefix = typeof(NoShortCircuitCapacitors).GetMethod("disableEventQuestionMark");
+				var postfix = typeof(NoShortCircuitCapacitors).GetMethod("tellThePlayerTheDayWasSaved");
+				pat.Patch(doShortCircuitMethod, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+			}
+
 			//Similarly, with firefighting
 			//TODO - temporarily disabled until we can figure out why we're getting "invalid IL" errors
 			/*var FirefightMethod = AccessTools.TypeByName("JobGiver_FightFiresNearPoint").GetMethod("TryGiveJob", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -3118,7 +3129,7 @@ namespace SaveOurShip2
 		}
 	}
 
-	[HarmonyPatch(typeof(ShortCircuitUtility), "DoShortCircuit")]
+	// This patch is applied manually in ShipInteriorMod2.Initialize.
 	public static class NoShortCircuitCapacitors
 	{
 		[HarmonyPrefix]


### PR DESCRIPTION
RT Fuze and SoS2 patch the same ShortCircuitUtility.DoShortCircuit method, breaking each other. 

This commit disables patch from SoS2, but adds Fuze component to all ship capacitor types. Its level of surge protection matches max capacity of these batteries. So overall protection is exactly the same as before.