### PR TITLE
Registering PassingShip in a proper way

### DIFF
--- a/Source/1.4/ShipInteriorMod2.cs
+++ b/Source/1.4/ShipInteriorMod2.cs
@@ -5365,7 +5365,7 @@ namespace SaveOurShip2
 					Find.LetterStack.ReceiveLetter(TranslatorFormattedStringExtensions.Translate("SoSPsychicAmplifier"), TranslatorFormattedStringExtensions.Translate("SoSPsychicAmplifierDesc"), LetterDefOf.PositiveEvent);
 					AttackableShip ship = new AttackableShip();
 					ship.enemyShip = DefDatabase<EnemyShipDef>.GetNamed("MechPsychicAmp");
-					spaceMap.passingShipManager.passingShips.Add(ship);
+					spaceMap.passingShipManager.AddShip(ship);
 				}
 			}
 		}


### PR DESCRIPTION
Possible fix for an exception:
```
System.NullReferenceException: Object reference not set to an instance of an object
  at RimWorld.PassingShip.Depart () [0x00006] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.PassingShip.PassingShipTick () [0x00016] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at RimWorld.PassingShipManager.PassingShipManagerTick () [0x0001c] in <1782cb69665b4d3abcdadb97df9ae541>:0 
  at Verse.Map.MapPostTick () [0x000bc] in <1782cb69665b4d3abcdadb97df9ae541>:0 
```
It is caused by a PassingShip.map being null.