### PR TITLE
Bioship hooks

### DIFF
--- a/Source/1.4/Comp/CompEngineTrail.cs
+++ b/Source/1.4/Comp/CompEngineTrail.cs
@@ -94,7 +94,7 @@ namespace RimWorld
         public override void PostDraw()
         {
             base.PostDraw();
-            if (active)
+            if (!Props.reactionless && active)
             {
                 if (Props.energy)
                 {
@@ -142,19 +142,21 @@ namespace RimWorld
                 {
                     refuelComp.ConsumeFuel(Props.fuelUse);
                 }
-                //destroy stuff in plume
-                HashSet<Thing> toBurn = new HashSet<Thing>();
-                foreach (IntVec3 cell in rectToKill)
-                {
-                    foreach (Thing t in cell.GetThingList(parent.Map))
+                if (!Props.reactionless) { 
+                    //destroy stuff in plume
+                    HashSet<Thing> toBurn = new HashSet<Thing>();
+                    foreach (IntVec3 cell in rectToKill)
                     {
-                        if ((t.def.useHitPoints || t is Pawn) && t.def.altitudeLayer != AltitudeLayer.Terrain)
-                            toBurn.Add(t);
+                        foreach (Thing t in cell.GetThingList(parent.Map))
+                        {
+                            if ((t.def.useHitPoints || t is Pawn) && t.def.altitudeLayer != AltitudeLayer.Terrain)
+                                toBurn.Add(t);
+                        }
                     }
-                }
-                foreach (Thing t in toBurn)
-                {
-                    t.TakeDamage(new DamageInfo(DamageDefOf.Bomb, 100));
+                    foreach (Thing t in toBurn)
+                    {
+                        t.TakeDamage(new DamageInfo(DamageDefOf.Bomb, 100));
+                    }
                 }
             }
         }

--- a/Source/1.4/Comp/CompShipCombatShield.cs
+++ b/Source/1.4/Comp/CompShipCombatShield.cs
@@ -68,11 +68,9 @@ namespace RimWorld
 			stringBuilder.Append("ShipInsideRadius".Translate() + radius + "/" + radiusSet);
             return stringBuilder.ToString();
         }
-        public void HitShield(Projectile_ExplosiveShipCombat proj)
-        {
-            lastInterceptAngle = proj.DrawPos.AngleToFlat(parent.TrueCenter());
-            lastIntercepted = Find.TickManager.TicksGame;
 
+        public virtual float CalcHeatGenerated(Projectile_ExplosiveShipCombat proj)
+        {
             float heatGenerated = proj.DamageAmount * HeatDamageMult * Props.heatMultiplier;
             if (proj.def.projectile.damageDef==DamageDefOf.EMP)
                 heatGenerated *= 10;
@@ -80,7 +78,16 @@ namespace RimWorld
                 heatGenerated *= 1.5f;
             else if (proj is Projectile_TorpedoShipCombat)
                 heatGenerated /= 3;
-            else if (proj is Projectile_ExplosiveShipCombatLaser || proj is Projectile_ExplosiveShipCombatPsychic)
+            return heatGenerated;
+        }
+
+        public void HitShield(Projectile_ExplosiveShipCombat proj)
+        {
+            lastInterceptAngle = proj.DrawPos.AngleToFlat(parent.TrueCenter());
+            lastIntercepted = Find.TickManager.TicksGame;
+
+            float heatGenerated = CalcHeatGenerated(proj);
+            if (proj is Projectile_ExplosiveShipCombatLaser || proj is Projectile_ExplosiveShipCombatPsychic)
             {
                 ShipCombatLaserMote obj = (ShipCombatLaserMote)(object)ThingMaker.MakeThing(ThingDef.Named("ShipCombatLaserMote"));
                 obj.origin = (Vector3)typeof(Projectile).GetField("origin", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(proj);

--- a/Source/1.4/CompProps/CompProperties_EngineTrail.cs
+++ b/Source/1.4/CompProps/CompProperties_EngineTrail.cs
@@ -11,6 +11,7 @@ namespace RimWorld
 		public int width = 0;
 		public bool takeOff = false;
 		public bool energy = false;
+		public bool reactionless = false;
 		public CompProperties_EngineTrail()
 		{
 			this.compClass = typeof(CompEngineTrail);

--- a/Source/1.4/PlaceWorker/PlaceWorker_ShipEngine.cs
+++ b/Source/1.4/PlaceWorker/PlaceWorker_ShipEngine.cs
@@ -11,7 +11,8 @@ namespace RimWorld
     {
         public override AcceptanceReport AllowsPlacing(BuildableDef checkingDef, IntVec3 loc, Rot4 rot, Map map, Thing thingToIgnore = null, Thing thing = null)
         {
-            Building engineprev = map.listerBuildings.allBuildingsColonist.Where(x => x.TryGetComp<CompEngineTrail>() != null).FirstOrDefault();
+            Building engineprev = map.listerBuildings.allBuildingsColonist.Where(x => x.TryGetComp<CompEngineTrail>() != null 
+                && !x.TryGetComp<CompEngineTrail>().Props.reactionless).FirstOrDefault();
             if (engineprev == null || (engineprev != null && engineprev.Rotation == rot))
                 return AcceptanceReport.WasAccepted;
             else

--- a/Source/1.4/Verb/Verb_LaunchProjectileShip.cs
+++ b/Source/1.4/Verb/Verb_LaunchProjectileShip.cs
@@ -11,7 +11,7 @@ using RimworldMod;
 
 namespace RimWorld
 {
-    class Verb_LaunchProjectileShip : Verb_Shoot
+    public class Verb_LaunchProjectileShip : Verb_Shoot
     {
         public LocalTargetInfo shipTarget;
 


### PR DESCRIPTION
Adds hooks for bioship features.

Adds reactionless field to CompProperties_EngineTrail.cs

Updated CompEngineTrail so that if it is reactionless it will not animate the engine trail or burn things in engine plume

Update placework for thrust to exclude reactionless drives from determining ship orientation

Update CompShipCombatShield so that the heat multiplier logic is extracted to an extensible function.

Updates Verb_LaunchProjectileShip to be public.