### PR TITLE
Fix IComparable bug in ship bridge gizmo.

### DIFF
--- a/Source/1.4/Building/Building_ShipBridge.cs
+++ b/Source/1.4/Building/Building_ShipBridge.cs
@@ -25,7 +25,7 @@ namespace RimWorld
         public float ShipHeat = 0;
         public int shipIndex = -1;
         public bool TacCon = false;
-        public SortedSet<ThingDef> nonRotatableObjects = new SortedSet<ThingDef>();
+        public HashSet<ThingDef> nonRotatableObjects = new HashSet<ThingDef>();
 
         bool selected = false;
         public List<Building> cachedShipParts;


### PR DESCRIPTION
Fixes an issue where if there were non-rotatable buildings on the ship but none of those buildings implemented `IComparable`, the `Building_ShipBridge.GetGizmos` would fail because it used a `SortedSet` to store said non-rotating buildings.

This was only an issue if the ship maker kit was running. 

The fix is to simply change the sorted set to a hashset - there is no need for the sorting and it is for diagnostics only anyway.

An example error from a user below:
```
System.ArgumentException: At least one object must implement IComparable.
  at System.Collections.Comparer.Compare (System.Object a, System.Object b) [0x00069] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Collections.Generic.ObjectComparer`1[T].Compare (T x, T y) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Collections.Generic.SortedSet`1[T].AddIfNotPresent (T item) [0x00059] in <ef151b6abb5d474cb2c1cb8906a8b5a4>:0 
  at System.Collections.Generic.SortedSet`1[T].Add (T item) [0x00000] in <ef151b6abb5d474cb2c1cb8906a8b5a4>:0 
  at RimWorld.Building_ShipBridge+<GetGizmos>d__20.MoveNext () [0x00345] in <669c8cf9c9a345ed9782ad418387894c>:0 
  at System.Collections.Generic.List`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x00077] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00018] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at PerformanceOptimizer.Optimization_InspectGizmoGrid_DrawInspectGizmoGridFor.GetGizmosFast (Verse.ISelectable selectable) [0x00015] in <ff2f7979eadc4e60a83422142889b973>:0 
  at (wrapper dynamic-method) RimWorld.InspectGizmoGrid.RimWorld.InspectGizmoGrid.DrawInspectGizmoGridFor_Patch0(System.Collections.Generic.IEnumerable`1<object>,Verse.Gizmo&) currentSelectable: ShipPilotSeatMini27976
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch3 (string)
Verse.Log:ErrorOnce (string,int)
(wrapper dynamic-method) RimWorld.InspectGizmoGrid:RimWorld.InspectGizmoGrid.DrawInspectGizmoGridFor_Patch0 (System.Collections.Generic.IEnumerable`1<object>,Verse.Gizmo&)
RimWorld.MainTabWindow_Inspect:DrawInspectGizmos ()
RimWorld.InspectPaneUtility:ExtraOnGUI (RimWorld.IInspectPane)
RimWorld.MainTabWindow_Inspect:ExtraOnGUI ()
Verse.WindowStack:WindowStackOnGUI ()
(wrapper dynamic-method) RimWorld.UIRoot_Play:RimWorld.UIRoot_Play.UIRootOnGUI_Patch3 (RimWorld.UIRoot_Play)
(wrapper dynamic-method) Verse.Root:Verse.Root.OnGUI_Patch2 (Verse.Root)
```

Thanks.