### PR TITLE
Optimize ColonistBarOnGUI

### DIFF
--- a/Source/1.4/Comp/EnvironmentCachingUtility.cs
+++ b/Source/1.4/Comp/EnvironmentCachingUtility.cs
@@ -9,6 +9,7 @@ namespace RimworldMod
 
         private Dictionary<int, bool> spaceMaps = new Dictionary<int, bool>();
         public HashSet<Thing> shuttleCache = new HashSet<Thing>();
+        public List<RimWorld.ShipHeatMapComp> shipHeatMapCompCache = new List<RimWorld.ShipHeatMapComp>();
 
         public EnvironmentCachingUtility(Game game)
         {

--- a/Source/1.4/Comp/ShipHeatMapComp.cs
+++ b/Source/1.4/Comp/ShipHeatMapComp.cs
@@ -12,7 +12,6 @@ namespace RimWorld
 {
     public class ShipHeatMapComp : MapComponent
     {
-        public static List<ShipHeatMapComp> shipHeatMapCompCache = new List<ShipHeatMapComp>();
         List<ShipHeatNet> cachedNets = new List<ShipHeatNet>();
         public List<CompShipHeat> cachedPipes = new List<CompShipHeat>();
 
@@ -24,11 +23,11 @@ namespace RimWorld
         {
             grid = new int[map.cellIndices.NumGridCells];
             heatGridDirty = true;
-            shipHeatMapCompCache.Add(this);
+            RimworldMod.AccessExtensions.Utility.shipHeatMapCompCache.Add(this);
         }
         public override void MapRemoved()
         {
-            shipHeatMapCompCache.Remove(this);
+            RimworldMod.AccessExtensions.Utility.shipHeatMapCompCache.Remove(this);
             base.MapRemoved();
         }
         public override void MapComponentUpdate()

--- a/Source/1.4/Comp/ShipHeatMapComp.cs
+++ b/Source/1.4/Comp/ShipHeatMapComp.cs
@@ -12,6 +12,7 @@ namespace RimWorld
 {
     public class ShipHeatMapComp : MapComponent
     {
+        public static List<ShipHeatMapComp> shipHeatMapCompCache = new List<ShipHeatMapComp>();
         List<ShipHeatNet> cachedNets = new List<ShipHeatNet>();
         public List<CompShipHeat> cachedPipes = new List<CompShipHeat>();
 
@@ -23,6 +24,12 @@ namespace RimWorld
         {
             grid = new int[map.cellIndices.NumGridCells];
             heatGridDirty = true;
+            shipHeatMapCompCache.Add(this);
+        }
+        public override void MapRemoved()
+        {
+            shipHeatMapCompCache.Remove(this);
+            base.MapRemoved();
         }
         public override void MapComponentUpdate()
         {

--- a/Source/1.4/HarmonyPatches.cs
+++ b/Source/1.4/HarmonyPatches.cs
@@ -28,7 +28,7 @@ namespace SaveOurShip2
 		{
 			Map mapPlayer = null;
 			ShipHeatMapComp playerShipComp = null;
-			var list = RimWorld.ShipHeatMapComp.shipHeatMapCompCache;
+			var list = AccessExtensions.Utility.shipHeatMapCompCache;
 			for (int i = list.Count; i-- > 0;)
 			{
 				playerShipComp = list[i];

--- a/Source/1.4/HarmonyPatches.cs
+++ b/Source/1.4/HarmonyPatches.cs
@@ -26,10 +26,20 @@ namespace SaveOurShip2
 	{
 		public static void Postfix(ColonistBar __instance)
 		{
-			Map mapPlayer = Find.Maps.Where(m => m.GetComponent<ShipHeatMapComp>().InCombat && !m.GetComponent<ShipHeatMapComp>().ShipCombatMaster).FirstOrDefault();
+			Map mapPlayer = null;
+			ShipHeatMapComp playerShipComp = null;
+			var list = RimWorld.ShipHeatMapComp.shipHeatMapCompCache;
+			for (int i = list.Count; i-- > 0;)
+			{
+				playerShipComp = list[i];
+				if (playerShipComp.InCombat && !playerShipComp.ShipCombatMaster)
+				{
+					mapPlayer = playerShipComp.map;
+					break;
+				}
+			}
 			if (mapPlayer != null)
 			{
-				var playerShipComp = mapPlayer.GetComponent<ShipHeatMapComp>();
 				var enemyShipComp = mapPlayer.GetComponent<ShipHeatMapComp>().MasterMapComp;
 				if (enemyShipComp == null || playerShipComp.MapRootList.Count == 0 || playerShipComp.MapRootList[0] == null || !playerShipComp.MapRootList[0].Spawned)
 					return;

--- a/Source/1.4/WorldSwitchUtility.cs
+++ b/Source/1.4/WorldSwitchUtility.cs
@@ -252,9 +252,6 @@ namespace SaveOurShip2
                 Log.Warning("SOS2: Mechanoid faction not found! Parts of SOS2 will likely fail to function properly!");
             if (!Find.FactionManager.AllFactions.Any(f => f.def == FactionDefOf.Insect))
                 Log.Warning("SOS2: Insect faction not found! SOS2 gameplay experience will be affected.");
-            
-            //Handle cache refreshing
-            RimWorld.ShipHeatMapComp.shipHeatMapCompCache = new List<RimWorld.ShipHeatMapComp>(); //Clear cache
         }
 
 		public override void ExposeData() {

--- a/Source/1.4/WorldSwitchUtility.cs
+++ b/Source/1.4/WorldSwitchUtility.cs
@@ -252,6 +252,9 @@ namespace SaveOurShip2
                 Log.Warning("SOS2: Mechanoid faction not found! Parts of SOS2 will likely fail to function properly!");
             if (!Find.FactionManager.AllFactions.Any(f => f.def == FactionDefOf.Insect))
                 Log.Warning("SOS2: Insect faction not found! SOS2 gameplay experience will be affected.");
+            
+            //Handle cache refreshing
+            RimWorld.ShipHeatMapComp.shipHeatMapCompCache = new List<RimWorld.ShipHeatMapComp>(); //Clear cache
         }
 
 		public override void ExposeData() {


### PR DESCRIPTION
ColonistBarOnGUI is the heaviest hitting patch on the profiler, so I spent some time with it.

Instead of processing every map and digging through its components every frame, this just processes a list cache of the component in question. Has about 1/10th the performance impact.

The ShipHeatMapComp will add itself to a static cache on its constructor, and remove on a map removal override. In order to clear the static cache on a game reload, we use the world component's init, which is called at an ideal time. Alternatively if you don't want to piggyback this responsibility there you'd handle it via a harmony patch on World.FinalizeInit instead, either way works.