### PR TITLE
Fixed pawns not auto-refueling ship reactors to full target capacity

### DIFF
--- a/1.4/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1926,15 +1926,16 @@
 			<li Class="CompProperties_Refuelable">
 				<compClass>CompRefuelableOverdrivable</compClass>
 				<targetFuelLevelConfigurable>true</targetFuelLevelConfigurable>
-				<initialConfigurableTargetFuelLevel>2500</initialConfigurableTargetFuelLevel>
+				<initialConfigurableTargetFuelLevel>2500.0</initialConfigurableTargetFuelLevel>
 				<fuelConsumptionRate>10</fuelConsumptionRate>
-				<fuelCapacity>2500</fuelCapacity>
+				<fuelCapacity>2500.0</fuelCapacity>
 				<fuelFilter>
 					<thingDefs>
 						<li>ShuttleFuelPods</li>
 					</thingDefs>
 				</fuelFilter>
 				<showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
+				<autoRefuelPercent>0.95</autoRefuelPercent>
 			</li>
 			<li Class="CompProperties_ShipHeat">
 				<compClass>CompShipHeatSource</compClass>
@@ -2015,15 +2016,16 @@
 			<li Class="CompProperties_Refuelable">
 				<compClass>CompRefuelableOverdrivable</compClass>
 				<targetFuelLevelConfigurable>true</targetFuelLevelConfigurable>
-				<initialConfigurableTargetFuelLevel>500</initialConfigurableTargetFuelLevel>
+				<initialConfigurableTargetFuelLevel>500.0</initialConfigurableTargetFuelLevel>
 				<fuelConsumptionRate>3</fuelConsumptionRate>
-				<fuelCapacity>500</fuelCapacity>
+				<fuelCapacity>500.0</fuelCapacity>
 				<fuelFilter>
 					<thingDefs>
 						<li>ShuttleFuelPods</li>
 					</thingDefs>
 				</fuelFilter>
 				<showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
+				<autoRefuelPercent>0.95</autoRefuelPercent>
 			</li>
 			<li Class="CompProperties_ShipHeat">
 				<compClass>CompShipHeatSource</compClass>


### PR DESCRIPTION
I know this bug has been around for a while (it makes my OCD violently ill), and I noticed pawns would always stop fueling the reactor at roughly 1/3 of target capacity. After some digging I found that CompProperties_Refuelable has a variable `autoRefuelPercent` set to 0.3f or 30%. Ship engines and the hullfoam distributor actually already have this tag in their defs set to 1, so this appears to have just been an oversight for the reactors.

I chose 0.95 so pawns aren't constantly refilling the reactor after a single unit of fuel is consumed.
Also added decimal points to their fuel values for consistency.