### PR TITLE
Satellite fix

### DIFF
--- a/1.4/Defs/HediffDefs/Hediffs_Space.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Space.xml
@@ -427,7 +427,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
-					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">2</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>

--- a/1.4/Defs/HediffDefs/Hediffs_Space.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Space.xml
@@ -359,6 +359,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>
@@ -426,6 +427,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>

--- a/1.5/Defs/HediffDefs/Hediffs_Space.xml
+++ b/1.5/Defs/HediffDefs/Hediffs_Space.xml
@@ -427,7 +427,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
-					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">2</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>

--- a/1.5/Defs/HediffDefs/Hediffs_Space.xml
+++ b/1.5/Defs/HediffDefs/Hediffs_Space.xml
@@ -359,6 +359,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>
@@ -426,6 +427,7 @@
 					<DecompressionResistance>1</DecompressionResistance>
 					<HypoxiaResistance>1</HypoxiaResistance>
 					<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
+					<MechFormingSpeed  MayRequire="Ludeon.RimWorld.Biotech">1</MechFormingSpeed>
 				</statOffsets>
 				<capMods>
 					<li>

--- a/Source/1.5/ScenPart/ScenPart_StartInSpace.cs
+++ b/Source/1.5/ScenPart/ScenPart_StartInSpace.cs
@@ -191,12 +191,27 @@ namespace SaveOurShip2
 			ScenPart_StartInSpace scen = (ScenPart_StartInSpace)Current.Game.Scenario.parts.FirstOrDefault(s => s is ScenPart_StartInSpace);
 			Map spaceMap = Find.CurrentMap;
 			List<List<Thing>> list = new List<List<Thing>>();
+			List<Thing> list3 = new List<Thing>();
 			foreach (Pawn startingAndOptionalPawn in Find.GameInitData.startingAndOptionalPawns)
 			{
 				List<Thing> list2 = new List<Thing>{ startingAndOptionalPawn };
 				list.Add(list2);
+				foreach (ThingDefCount posession in Find.GameInitData.startingPossessions[startingAndOptionalPawn])
+				{
+					Thing thing = ThingMaker.MakeThing(posession.ThingDef, GenStuff.RandomStuffFor(posession.ThingDef));
+					if (posession.ThingDef.IsIngestible && posession.ThingDef.ingestible.IsMeal)
+					{
+						FoodUtility.GenerateGoodIngredients(thing, Faction.OfPlayer.ideos.PrimaryIdeo);
+					}
+					if (thing.def.Minifiable)
+					{
+						thing = thing.MakeMinified();
+					}
+					thing.stackCount = posession.Count;
+					list3.Add(thing);
+				}
 			}
-			List<Thing> list3 = new List<Thing>();
+			
 			foreach (ScenPart allPart in Find.Scenario.AllParts)
 			{
 				list3.AddRange(allPart.PlayerStartingThings());


### PR DESCRIPTION
 Fixes to satellite core. 
1. Red log error on no raid points set.
2. Raid to player ship was spawning on every space map, not just there.
3. Worker mechanoids in invasion.
4. No raid at site when deconstructing sat core, added normal raid, as
    deconstrucrted sat will not tick and send mechs for invasion.

    Because AI formgels and archotech formgels could not install mech
    geatation speed implant, get better speed directly.

    Fix: handle possessions feature in space start scenario, so that those
    possession items actually spawn.

