### PR TITLE
Torpedo tube fixes

### DIFF
--- a/Source/1.5/Building/Building_ShipTurret.cs
+++ b/Source/1.5/Building/Building_ShipTurret.cs
@@ -866,6 +866,7 @@ namespace SaveOurShip2
 					if (!torpTypes.Contains(torp))
 						torpTypes.Add(torp);
 				}
+				torpTypes = torpTypes.OrderBy(t => t.defName).ToList();
 				foreach (ThingDef torp in torpTypes)
 				{
 					Command_Toggle command_Toggle = new Command_Toggle

--- a/Source/1.5/Jobs/JobDriver_LoadTorpedoTube.cs
+++ b/Source/1.5/Jobs/JobDriver_LoadTorpedoTube.cs
@@ -31,6 +31,8 @@ namespace SaveOurShip2
 		{
 			if (Tube.torpComp.FullyLoaded)
 				return false;
+			if (base.pawn.Faction != Tube.Faction)
+				return false;
 			return ReservationUtility.Reserve(base.pawn, base.job.targetA, base.job, 1, 1, null, true);
 		}
 


### PR DESCRIPTION
1. Pawns respect tube faction and don't load other faction tubes.
2. Gizmos for allow firing each type of torpedoes are ordered.