### PR TITLE
Do not show number of amplifiers on spinal weapon when fog hides amplifiers and capacitor room

### DIFF
--- a/Source/1.5/Building/Building_ShipTurret.cs
+++ b/Source/1.5/Building/Building_ShipTurret.cs
@@ -678,10 +678,15 @@ namespace SaveOurShip2
 			}
 			if (spinalComp != null)
 			{
-				if (AmplifierCount != -1)
-					stringBuilder.AppendLine("SoS.AmplifierCount".Translate(AmplifierCount));
-				else
-					stringBuilder.AppendLine("SoS.SpinalCapNotFound".Translate());
+				// Do not show numer of amplifiers when room with capacitor and amplifiers is fogged
+				IntVec3 positionBehindBarrel = Position + GenAdj.CardinalDirectionsAround[Rotation.rotInt] * 2;
+				if (!positionBehindBarrel.Fogged(this.Map))
+				{
+					if (AmplifierCount != -1)
+						stringBuilder.AppendLine("SoS.AmplifierCount".Translate(AmplifierCount));
+					else
+						stringBuilder.AppendLine("SoS.SpinalCapNotFound".Translate());
+				}
 			}
 			if (torpComp != null)
 			{


### PR DESCRIPTION
Do not show number of amplifiers on spinal weapon when fog hides amplifiers and capacitor room