### PR TITLE
More bugfixes!

### DIFF
--- a/Source/1.5/Comp/CompShipHeatShield.cs
+++ b/Source/1.5/Comp/CompShipHeatShield.cs
@@ -138,7 +138,10 @@ namespace SaveOurShip2
 				if (breakComp != null)
 					breakComp.DoBreakdown();
 				else
+				{
 					parentVehicle.statHandler.SetComponentHealth("shieldGenerator", 0);
+					parentVehicle.Map.GetComponent<ListerVehiclesRepairable>().Notify_VehicleTookDamage(parentVehicle);
+				}
 				if(parent.Spawned)
 					GenExplosion.DoExplosion(parent.Position, parent.Map, 1.9f, DamageDefOf.Flame, parent);
 				SoundDef.Named("EnergyShield_Broken").PlayOneShot(new TargetInfo(parent));

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4276,8 +4276,8 @@ namespace SaveOurShip2
 				__result = false;
 				return;
 			}
-			if (__instance is Projectile_ExplosiveShip) //Handled natively
-				return;
+			/*if (__instance is Projectile_ExplosiveShip) //Handled natively
+				return;*/
 			if (__instance.Map == null)
 				return;
 			foreach(CompShipHeatShield shield in __instance.Map.GetComponent<ShipMapComp>().Shields)
@@ -4288,6 +4288,7 @@ namespace SaveOurShip2
 				pos.y = lastExactPos.y;
 				if(Vector3.Distance(lastExactPos, pos) > shield.radius && (Vector3.Distance(newExactPos, pos) <= shield.radius || Vector3.Distance((lastExactPos + newExactPos) / 2, pos) <= shield.radius))
                 {
+					//Log.Message("Hit shield - lastExactPos was " + lastExactPos + ", newExactPos was " + newExactPos + ", midpoint was " + ((lastExactPos + newExactPos) / 2) + ", shield pos was " + pos + ", radius was " + shield.radius);
 					shield.HitShield(__instance);
 					__result = true;
 					return;
@@ -4600,6 +4601,18 @@ namespace SaveOurShip2
 			}
 		}
 	}
+
+	[HarmonyPatch(typeof(MechanitorUtility), "ShouldBeMechanitor")]
+	public static class AIControlsMechs
+    {
+		public static void Postfix(Pawn pawn, ref bool __result)
+        {
+			if (ModsConfig.BiotechActive && (pawn.health.hediffSet.HasHediff(ResourceBank.HediffDefOf.SoSHologramMachine) || pawn.health.hediffSet.HasHediff(ResourceBank.HediffDefOf.SoSHologramArchotech)))
+			{
+				__result = true;
+			}
+		}
+    }
 
 	[HarmonyPatch(typeof(ITab_Vehicle_Upgrades), "DrawButtons")] //Destructive patch, remove this when/if VF adds upgrade failure reasons
 	public static class TEMPVerboseUpgradeFailure

--- a/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
@@ -13,7 +13,8 @@ namespace SaveOurShip2
 		public override void Tick()
 		{
 			base.Tick();
-			if (this.Spawned)
+			//Replaced by new Harmony shield patch
+			/*if (this.Spawned)
 			{
 				foreach (CompShipHeatShield shield in this.Map.GetComponent<ShipMapComp>().Shields)
 				{
@@ -23,7 +24,7 @@ namespace SaveOurShip2
 						break;
 					}
 				}
-			}
+			}*/
 			if (!(this is Projectile_ExplosiveShipPsychic))
 			{
 				if (this.Spawned && this.ExactPosition.ToIntVec3().GetThingList(this.Map).Any(t => t is Building b && (b.TryGetComp<CompShipCachePart>()?.Props.isPlating ?? false)))


### PR DESCRIPTION
Fixed shuttle lasers/torpedoes hitting their own shields Moved all shield checks into ShieldsWithoutDLC Harmony patch Shuttles are now correctly marked as repairable when their shields break Formgels with innate mechanitor abilities (AI core and archotech spore) now properly count as mechanitors